### PR TITLE
fixed click event bug

### DIFF
--- a/scripts/parkAreas.js
+++ b/scripts/parkAreas.js
@@ -12,8 +12,8 @@ document.addEventListener('click', (event) => {
         counter++;
       }
     }
+    window.alert(`There are ${counter} guests in this area`);
   }
-  window.alert(`There are ${counter} guests in this area`);
 });
 
 export const parkAreaList = () => {


### PR DESCRIPTION
The window alert for the click event listener was showing up when the user clicked on anything on the page, so I fixed it so that it only shows up when a park area is clicked on